### PR TITLE
Fix: Incorrect signal when in transition

### DIFF
--- a/TallyBoxOutput.cpp
+++ b/TallyBoxOutput.cpp
@@ -194,7 +194,8 @@ bool handleBrightnessSettingMode()
     }
     else
     {
-      brightnessSettingModeEnabled = false;
+      /*timeout exceeded, disable setting mode*/
+      setBrightnessSettingMode(OUTPUT_NONE, false);
     }
   } 
   return skipRealOutput;
@@ -234,7 +235,7 @@ void outputUpdate(uint16_t currentTick, bool dataIsValid, bool inTransition)
   }
   else
   {
-    /*WARNING case: smootly wave between green and red to indicate disconnection*/
+    /*WARNING case: smoothly wave between green and red to indicate disconnection*/
     int32_t wGreen, wRed;
     getWarningLevels(currentTick, wGreen, wRed);
     analogWrite(PIN_GREEN, wGreen);

--- a/TallyBoxOutput.cpp
+++ b/TallyBoxOutput.cpp
@@ -58,6 +58,8 @@ bool getBrightnessSettingMode(tallyBoxOutput_t& ch)
   bool ret = false;
   ret = brightnessSettingModeEnabled;
   ch = brightnessSettingModeChannel;
+  
+  return ret;
 }
 
 

--- a/TallyBoxOutput.hpp
+++ b/TallyBoxOutput.hpp
@@ -18,9 +18,11 @@ void getOutputTxData(uint8_t& bsmEnabled, uint16_t& bsmCounter, uint16_t& bsmCha
 void putOutputRxData(uint8_t& bsmEnabled, uint16_t& bsmCounter, uint16_t& bsmChannel, uint16_t& greenBrightness, uint16_t& redBrightness);
 
 void setBrightnessSettingMode(tallyBoxOutput_t ch, bool enable);
+bool getBrightnessSettingMode(tallyBoxOutput_t& ch);
+
 void setOutputBrightness(uint16_t percent, tallyBoxOutput_t ch);
 uint16_t getOutputBrightness(tallyBoxOutput_t ch);
-void outputUpdate(uint16_t currentTick, bool dataIsValid, bool tallyPreview, bool tallyProgram);
-void outputUpdate(uint16_t currentTick, bool dataIsValid);
+void outputUpdate(uint16_t currentTick, bool dataIsValid, bool tallyPreview, bool tallyProgram, bool inTransition);
+void outputUpdate(uint16_t currentTick, bool dataIsValid, bool inTransition);
 
 #endif

--- a/TallyBoxPeerNetwork.hpp
+++ b/TallyBoxPeerNetwork.hpp
@@ -5,7 +5,7 @@
 #include "TallyBoxConfiguration.hpp"
 
 void peerNetworkInitialize(uint16_t localPort);
-void peerNetworkSend(tallyBoxConfig_t& c, uint16_t greenChannel, uint16_t redChannel);
-bool peerNetworkReceive(uint16_t& greenChannel, uint16_t& redChannel);
+void peerNetworkSend(tallyBoxConfig_t& c, uint16_t greenChannel, uint16_t redChannel, bool inTransition);
+bool peerNetworkReceive(uint16_t& greenChannel, uint16_t& redChannel, bool& inTransition);
 
 #endif


### PR DESCRIPTION
Fix for https://github.com/djtremolo/TallyBox/issues/1

Initial fix for bringing the inTransition signal in from ATEM and feeding it to secondary units via PeerNetwork - not tested.


